### PR TITLE
Revert "reduce NRF_SDH_BLE_GAP_EVENT_LENGTH value"

### DIFF
--- a/app/sdk_config.h
+++ b/app/sdk_config.h
@@ -11370,7 +11370,7 @@
 // <i> The time set aside for this connection on every connection interval in 1.25 ms units.
 
 #ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
-#define NRF_SDH_BLE_GAP_EVENT_LENGTH 5
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
 #endif
 
 // <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size. 


### PR DESCRIPTION
This reverts commit ea9c5f5df535738d867c01827b632f14ac1a203e.